### PR TITLE
Implementanção da função Rect::SetCenter 

### DIFF
--- a/include/Rect.hpp
+++ b/include/Rect.hpp
@@ -19,6 +19,9 @@ class Rect {
   Rect GetCentered(Vec2 pos) const;
   Rect GetCentered(float x, float y) const;
 
+  void SetCenter(Vec2 pos);
+  void SetCenter(float x, float y);
+
   float Distance(const Rect& rect) const;
 
   bool Contains(const Vec2& point) const;

--- a/src/Collider.cpp
+++ b/src/Collider.cpp
@@ -20,7 +20,7 @@ void Collider::Update(float dt) {
   box = associated.box;
   box.w *= scale.x;
   box.y *= scale.y;
-  box = box.GetCentered(associated.box.Center());
+  box.SetCenter(associated.box.Center());
 
   box += offset.GetRotated(Helpers::deg_to_rad(associated.angleDeg));
 }

--- a/src/Rect.cpp
+++ b/src/Rect.cpp
@@ -19,6 +19,10 @@ Rect Rect::GetCentered(float centerX, float centerY) const {
   return Rect(centerX - w / 2, centerY - h / 2, w, h);
 }
 
+void Rect::SetCenter(Vec2 pos) { *this = GetCentered(pos); }
+
+void Rect::SetCenter(float x, float y) { *this = GetCentered(x, y); }
+
 bool Rect::Contains(const Vec2& point) const {
   if (x > point.x || (x + w) < point.x) {
     return false;

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -98,7 +98,7 @@ void Sprite::SetScaleX(float scaleX, float scaleY) {
     associated.box.h = GetHeight();
   }
 
-  associated.box = associated.box.GetCentered(oldCenter);
+  associated.box.SetCenter(oldCenter);
 }
 
 void Sprite::SetFrame(int frame) {


### PR DESCRIPTION
Anteriormente, era necessário escrever `box = box.GetCentered(position)` para deslocar o centro de um `Rect` para as coordenadas `position`, o que pode ser um tanto quanto verboso e com baixa legibilidade. O método `Rect::GetCentered` e sua overload continuam no código para nos precavermos de situações inesperadas sendo esse patch a implementação de wrappers de forma que definir um centro para uma box possa ser feito das seguintes formas `box.SetCenter(position)` e `box.SetCenter(x,y)`.